### PR TITLE
🐛 fix TimingUtility::getInstance on the condition that the Services.y…

### DIFF
--- a/Classes/Utility/TimingUtility.php
+++ b/Classes/Utility/TimingUtility.php
@@ -7,6 +7,7 @@ namespace Kanti\ServerTiming\Utility;
 use Exception;
 use Kanti\ServerTiming\Dto\ScriptResult;
 use Kanti\ServerTiming\Dto\StopWatch;
+use Kanti\ServerTiming\Service\RegisterShutdownFunction\RegisterShutdownFunction;
 use Kanti\ServerTiming\Service\RegisterShutdownFunction\RegisterShutdownFunctionInterface;
 use Kanti\ServerTiming\Service\SentryService;
 use Kanti\ServerTiming\Service\ConfigService;
@@ -34,7 +35,7 @@ final class TimingUtility implements SingletonInterface
 
     public static function getInstance(): TimingUtility
     {
-        return static::$instance ??= GeneralUtility::makeInstance(TimingUtility::class);
+        return static::$instance ??= GeneralUtility::makeInstance(TimingUtility::class, new RegisterShutdownFunction(), new ConfigService());
     }
 
     /** @var StopWatch[] */


### PR DESCRIPTION
…ml could not ben ready (early setup process)